### PR TITLE
Allow system applications to write on sysfs

### DIFF
--- a/prebuilts/api/26.0/private/app.te
+++ b/prebuilts/api/26.0/private/app.te
@@ -41,10 +41,10 @@ allow { appdomain -isolated_app } tmpfs:lnk_file r_file_perms;
 # Search /storage/emulated tmpfs mount.
 allow appdomain tmpfs:dir r_dir_perms;
 
-userdebug_or_eng(`
-  # Notify zygote of the wrapped process PID when using --invoke-with.
-  allow appdomain zygote:fifo_file write;
+# Notify zygote of the wrapped process PID when using --invoke-with.
+allow appdomain zygote:fifo_file write;
 
+userdebug_or_eng(`
   # Allow apps to create and write method traces in /data/misc/trace.
   allow appdomain method_trace_data_file:dir w_dir_perms;
   allow appdomain method_trace_data_file:file { create w_file_perms };
@@ -68,9 +68,6 @@ allow appdomain appdomain:fifo_file rw_file_perms;
 
 # Communicate with surfaceflinger.
 allow appdomain surfaceflinger:unix_stream_socket { read write setopt getattr getopt shutdown };
-
-# Query whether a Surface supports wide color
-allow { appdomain -isolated_app } hal_configstore_ISurfaceFlingerConfigs:hwservice_manager find;
 
 # App sandbox file accesses.
 allow { appdomain -isolated_app } app_data_file:dir create_dir_perms;
@@ -225,8 +222,8 @@ allow { appdomain -isolated_app -ephemeral_app } sdcardfs:dir create_dir_perms;
 allow { appdomain -isolated_app -ephemeral_app } sdcardfs:file create_file_perms;
 # This should be removed if sdcardfs is modified to alter the secontext for its
 # accesses to the underlying FS.
-allow { appdomain -isolated_app -ephemeral_app } media_rw_data_file:dir create_dir_perms;
-allow { appdomain -isolated_app -ephemeral_app } media_rw_data_file:file create_file_perms;
+allow { appdomain -isolated_app -ephemeral_app } { media_rw_data_file vfat }:dir create_dir_perms;
+allow { appdomain -isolated_app -ephemeral_app } { media_rw_data_file vfat }:file create_file_perms;
 
 # Access OBBs (vfat images) mounted by vold (b/17633509)
 # File write access allowed for FDs returned through Storage Access Framework
@@ -314,11 +311,6 @@ pdx_use({ appdomain -isolated_app -ephemeral_app }, bufferhub_client)
 allow appdomain runas_exec:file getattr;
 # Others are either allowed elsewhere or not desired.
 
-# For cts/tests/tests/security/src/android/security/cts/SELinuxTest.java
-# Check SELinux policy and contexts.
-selinux_check_access(appdomain)
-selinux_check_context(appdomain)
-
 # Apps receive an open tun fd from the framework for
 # device traffic. Do not allow untrusted app to directly open tun_device
 allow { appdomain -isolated_app -ephemeral_app } tun_device:chr_file { read write getattr ioctl append };
@@ -330,6 +322,9 @@ allow appdomain adbd:fd use;
 allow appdomain adbd:unix_stream_socket { getattr getopt ioctl read write shutdown };
 
 allow appdomain cache_file:dir getattr;
+
+# Allow apps to run with asanwrapper.
+with_asan(`allow appdomain asanwrapper_exec:file rx_file_perms;')
 
 ###
 ### Neverallow rules
@@ -471,13 +466,17 @@ neverallow appdomain efs_file:dir_file_class_set write;
 neverallow { appdomain -shell } efs_file:dir_file_class_set read;
 
 # Write to various pseudo file systems.
-neverallow { appdomain -bluetooth -nfc }
+neverallow { appdomain -bluetooth -nfc -platform_app}
     sysfs:dir_file_class_set write;
 neverallow appdomain
     proc:dir_file_class_set write;
 
 # Access to syslog(2) or /proc/kmsg.
 neverallow appdomain kernel:system { syslog_read syslog_mod syslog_console };
+
+# SELinux is not an API for apps to use
+neverallow { appdomain -shell } *:security { compute_av check_context };
+neverallow { appdomain -shell } *:netlink_selinux_socket *;
 
 # Ability to perform any filesystem operation other than statfs(2).
 # i.e. no mount(2), unmount(2), etc.

--- a/prebuilts/api/26.0/private/seapp_contexts
+++ b/prebuilts/api/26.0/private/seapp_contexts
@@ -102,7 +102,7 @@ user=radio seinfo=platform domain=radio type=radio_data_file
 user=shared_relro domain=shared_relro
 user=shell seinfo=platform domain=shell type=shell_data_file
 user=_isolated domain=isolated_app levelFrom=user
-user=_app seinfo=platform domain=platform_app type=app_data_file levelFrom=user
+user=_app seinfo=platform domain=platform_app type=app_data_file
 user=_app isV2App=true isEphemeralApp=true domain=ephemeral_app type=app_data_file levelFrom=user
 user=_app isV2App=true domain=untrusted_v2_app type=app_data_file levelFrom=user
 user=_app isPrivApp=true domain=priv_app type=app_data_file levelFrom=user

--- a/private/app.te
+++ b/private/app.te
@@ -466,7 +466,7 @@ neverallow appdomain efs_file:dir_file_class_set write;
 neverallow { appdomain -shell } efs_file:dir_file_class_set read;
 
 # Write to various pseudo file systems.
-neverallow { appdomain -bluetooth -nfc }
+neverallow { appdomain -bluetooth -nfc -platform_app}
     sysfs:dir_file_class_set write;
 neverallow appdomain
     proc:dir_file_class_set write;

--- a/private/seapp_contexts
+++ b/private/seapp_contexts
@@ -102,7 +102,7 @@ user=radio seinfo=platform domain=radio type=radio_data_file
 user=shared_relro domain=shared_relro
 user=shell seinfo=platform domain=shell type=shell_data_file
 user=_isolated domain=isolated_app levelFrom=user
-user=_app seinfo=platform domain=platform_app type=app_data_file levelFrom=user
+user=_app seinfo=platform domain=platform_app type=app_data_file
 user=_app isV2App=true isEphemeralApp=true domain=ephemeral_app type=app_data_file levelFrom=user
 user=_app isV2App=true domain=untrusted_v2_app type=app_data_file levelFrom=user
 user=_app isPrivApp=true domain=priv_app type=app_data_file levelFrom=user


### PR DESCRIPTION
Changes to support the Access Control board. In particular, allow the system applications to write on sysfs.